### PR TITLE
Document the need to add django.contrib.postgres to INSTALLED APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ INSTALLED_APPS = [
 
 By default, Django ModelSearch will index into the database configured in `DATABASES["default"]` and use PostgreSQL FTS, MySQL FTS, MariaDB FTS or SQLite FTS, if available.
 
-You can change the indexing configuration, or add additional backends with the `MODALSEARCH_BACKENDS` setting. For example, to configure Elasticsearch:
+If you are using PostgreSQL, you must additionally add `django.contrib.postgres` to your [`INSTALLED_APPS`](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-INSTALLED_APPS) setting.
+
+You can change the indexing configuration, or add additional backends with the `MODELSEARCH_BACKENDS` setting. For example, to configure Elasticsearch:
 
 ```python
 # settings.py

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -54,6 +54,8 @@ Here's a list of backends that Django Modelsearch supports out of the box.
 The database search backend searches content in the database using the full-text search features of the database backend in use (such as PostgreSQL FTS, SQLite FTS5).
 This backend is intended to be used for development and also should be good enough to use in production on sites that don't require any Elasticsearch specific features.
 
+If you use the PostgreSQL database backend, you must add `django.contrib.postgres` to your [`INSTALLED_APPS`](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-INSTALLED_APPS) setting.
+
 (modelsearch_backends_elasticsearch)=
 
 ### Elasticsearch/OpenSearch Backends

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ INSTALLED_APPS = [
 ]
 ```
 
+If you are using PostgreSQL, you must additionally add `django.contrib.postgres` to your [`INSTALLED_APPS`](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-INSTALLED_APPS) setting.
+
 ## Configuration
 
 Django Modelsearch indexes into database by default and it'll use the built-in full text search features of SQLite, MySQL, MariaDB and PostgreSQL with a fallback for other databases.

--- a/modelsearch/test/settings.py
+++ b/modelsearch/test/settings.py
@@ -85,6 +85,9 @@ DATABASES = {
     "default": dj_database_url.config(default="sqlite:///test_modelsearch.sqlite")
 }
 
+if DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql":
+    INSTALLED_APPS.append("django.contrib.postgres")
+
 
 # Search backend
 


### PR DESCRIPTION
Port of https://github.com/wagtail/wagtail/pull/13174

`django.contrib.postgres` should be added to INSTALLED_APPS when those functions are in use, and this is enforced as of Django 6.0: https://github.com/django/django/commit/74b31cd26b9ad4ad85f131850a734f02aae988bb