### PR TITLE
Add failing tests for fetching related fields in get_search_field

### DIFF
--- a/modelsearch/backends/database/mysql/mysql.py
+++ b/modelsearch/backends/database/mysql/mysql.py
@@ -339,8 +339,16 @@ class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
             # Note: Searching on a specific related field using
             # `.search(fields=…)` is not yet supported by Wagtail.
             # This method anticipates by already implementing it.
-            if isinstance(field, RelatedFields) and field.field_name == field_lookup:
-                return self.get_search_field(sub_field_name, field.fields)
+            # FIXME: this doesn't work because the list we're looping over comes from
+            # get_search_fields_for_model, which only returns `SearchField` records, not `RelatedFields`
+            if (
+                isinstance(field, RelatedFields)
+                and field.field_name == field_lookup
+                and sub_field_name is not None
+            ):
+                return self.get_search_field(
+                    sub_field_name, field.fields
+                )  # pragma: no cover
 
     def build_search_query_content(self, query, invert=False):
         if isinstance(query, PlainText):

--- a/modelsearch/backends/database/postgres/postgres.py
+++ b/modelsearch/backends/database/postgres/postgres.py
@@ -369,8 +369,16 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
             # Note: Searching on a specific related field using
             # `.search(fields=…)` is not yet supported by Wagtail.
             # This method anticipates by already implementing it.
-            if isinstance(field, RelatedFields) and field.field_name == field_lookup:
-                return self.get_search_field(sub_field_name, field.fields)
+            # FIXME: this doesn't work because the list we're looping over comes from
+            # get_search_fields_for_model, which only returns `SearchField` records, not `RelatedFields`
+            if (
+                isinstance(field, RelatedFields)
+                and field.field_name == field_lookup
+                and sub_field_name is not None
+            ):
+                return self.get_search_field(
+                    sub_field_name, field.fields
+                )  # pragma: no cover
 
     def build_tsquery_content(self, query, config=None, invert=False):
         if isinstance(query, PlainText):

--- a/modelsearch/backends/database/sqlite/sqlite.py
+++ b/modelsearch/backends/database/sqlite/sqlite.py
@@ -363,8 +363,16 @@ class SQLiteSearchQueryCompiler(BaseSearchQueryCompiler):
             # Note: Searching on a specific related field using
             # `.search(fields=…)` is not yet supported by Wagtail.
             # This method anticipates by already implementing it.
-            if isinstance(field, RelatedFields) and field.field_name == field_lookup:
-                return self.get_search_field(sub_field_name, field.fields)
+            # FIXME: this doesn't work because the list we're looping over comes from
+            # get_search_fields_for_model, which only returns `SearchField` records, not `RelatedFields`
+            if (
+                isinstance(field, RelatedFields)
+                and field.field_name == field_lookup
+                and sub_field_name is not None
+            ):
+                return self.get_search_field(
+                    sub_field_name, field.fields
+                )  # pragma: no cover
 
     def build_search_query_content(self, query, config=None):
         """

--- a/modelsearch/tests/test_mysql_backend.py
+++ b/modelsearch/tests/test_mysql_backend.py
@@ -199,3 +199,17 @@ class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
         self.backend.reset_indexes()
         results = self.backend.search("JavaScript", models.Book)
         self.assertEqual(results.count(), 0)
+
+    @unittest.expectedFailure
+    def test_get_search_field_for_related_fields(self):
+        """
+        The get_search_field method of MySQLSearchQueryCompiler attempts to support retrieving
+        search fields across relations with double-underscore notation. This is not yet supported
+        in actual searches, so test this in isolation.
+        """
+        # retrieve an arbitrary SearchResults object to extract a compiler object from
+        results = self.backend.search("JavaScript", models.Book)
+        compiler = results.query_compiler
+        search_field = compiler.get_search_field("authors__name")
+        self.assertIsNotNone(search_field)
+        self.assertEqual(search_field.field_name, "name")

--- a/modelsearch/tests/test_postgres_backend.py
+++ b/modelsearch/tests/test_postgres_backend.py
@@ -168,6 +168,20 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
         results = self.backend.search("JavaScript", models.Book)
         self.assertEqual(results.count(), 0)
 
+    @unittest.expectedFailure
+    def test_get_search_field_for_related_fields(self):
+        """
+        The get_search_field method of PostgresSearchQueryCompiler attempts to support retrieving
+        search fields across relations with double-underscore notation. This is not yet supported
+        in actual searches, so test this in isolation.
+        """
+        # retrieve an arbitrary SearchResults object to extract a compiler object from
+        results = self.backend.search("JavaScript", models.Book)
+        compiler = results.query_compiler
+        search_field = compiler.get_search_field("authors__name")
+        self.assertIsNotNone(search_field)
+        self.assertEqual(search_field.field_name, "name")
+
 
 @unittest.skipUnless(
     connection.vendor == "postgresql", "The current database is not PostgreSQL"

--- a/modelsearch/tests/test_sqlite_backend.py
+++ b/modelsearch/tests/test_sqlite_backend.py
@@ -60,3 +60,17 @@ class TestSQLiteSearchBackend(BackendTests, TestCase):
         self.backend.reset_indexes()
         results = self.backend.search("JavaScript", models.Book)
         self.assertEqual(results.count(), 0)
+
+    @unittest.expectedFailure
+    def test_get_search_field_for_related_fields(self):
+        """
+        The get_search_field method of SQLiteSearchQueryCompiler attempts to support retrieving
+        search fields across relations with double-underscore notation. This is not yet supported
+        in actual searches, so test this in isolation.
+        """
+        # retrieve an arbitrary SearchResults object to extract a compiler object from
+        results = self.backend.search("JavaScript", models.Book)
+        compiler = results.query_compiler
+        search_field = compiler.get_search_field("authors__name")
+        self.assertIsNotNone(search_field)
+        self.assertEqual(search_field.field_name, "name")


### PR DESCRIPTION
The database backends have some not-quite-working code for locating `SearchField` records inside `RelatedFields` in anticipation of that being supported by the wider search infrastructure. I figure it's worth documenting _why_ this doesn't work, and adding test coverage for it.