### PR TITLE
Fix RelatedFields.select_on_queryset for when modelcluster is not installed

### DIFF
--- a/modelsearch/test/settings.py
+++ b/modelsearch/test/settings.py
@@ -25,7 +25,6 @@ ALLOWED_HOSTS = ["localhost", "testserver"]
 INSTALLED_APPS = [
     "modelsearch.test.testapp",
     "modelsearch",
-    "modelcluster",
     "taggit",
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
The logic in 12449b431fa5cb3986992ef2ad111df4c71ca02b for making modelcluster optional was incorrect on two counts: firstly, it's never been a requirement to add modelcluster to INSTALLED_APPS (the Wagtail project template does, but the test settings don't). Secondly, the intent of the code is "perform a prefetch on any RelatedField except ParentalManyToManyField", so if ParentalManyToManyField is absent, we simply want to remove that exception, not the whole clause.

Without this fix, removing modelcluster from INSTALLED_APPS causes the tests in test_related_fields to fail.