### PR TITLE
Use queryish library for results objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">= 3.10"
 dependencies = [
   "Django (>5.0,<6)",
   "django-tasks>=0.7,<0.9",
+  "queryish>=0.3,<1",
 ]
 description = "A library for indexing Django models with Elasicsearch, OpenSearch or database and searching them with the Django ORM."
 readme = "README.md"


### PR DESCRIPTION
[queryish](https://github.com/wagtail/queryish/) is a library I created for wrapping arbitrary datasources with an API that's consistent with Django's queryset - originally so that we could have choosers in Wagtail that pick objects from a REST API instead of the local database. This of course is a good fit for django-modelsearch's BaseSearchResults class.

Refactoring BaseSearchResults on top of Queryish allows us to eliminate a chunk of code, benefit from Queryish's wider unit testing for features like slicing and result caching, and potentially support a larger subset of the Queryset API (`.first()` is a quick win that works now; with more work it could be possible to support chaining things like `.filter` and `.get` after the `search` clause).