### PR TITLE
Remove index name from mysql backend

### DIFF
--- a/modelsearch/backends/database/mysql/mysql.py
+++ b/modelsearch/backends/database/mysql/mysql.py
@@ -153,7 +153,6 @@ class ObjectIndexer:
 class MySQLIndex(BaseIndex):
     def __init__(self, backend):
         super().__init__(backend)
-        self.name = self.backend.index_name
 
         self.read_connection = connections[router.db_for_read(IndexEntry)]
         self.write_connection = connections[router.db_for_write(IndexEntry)]
@@ -277,9 +276,6 @@ class MySQLIndex(BaseIndex):
             if connection.vendor == "mysql"
         ]:
             IndexEntry._default_manager.all()._raw_delete(using=connection.alias)
-
-    def __str__(self):
-        return self.name
 
 
 class MySQLSearchQueryCompiler(BaseSearchQueryCompiler):
@@ -596,8 +592,6 @@ class MySQLSearchBackend(BaseSearchBackend):
 
     def __init__(self, params):
         super().__init__(params)
-        self.index_name = params.get("INDEX", "default")
-
         # MySQL backend currently has no config options
         self.config = None
         self.autocomplete_config = None


### PR DESCRIPTION
A little bit of cleanup we overlooked when reinstating the mysql backend - it was still setting a `name` property on the index, derived from the obsolete `INDEX` option.

Perhaps it's worth noting that since the requirement for indexes to have names was dropped in #15, running `rebuild_modelsearch_index` on non-Elasticsearch indexes now outputs the slightly unfriendly

```
Updating backend: default
default: Rebuilding index <modelsearch.backends.database.sqlite.sqlite.SQLiteIndex object at 0x12546cc50>
```
Is that something we should be concerned about?