### PR TITLE
Refresh index when inserting / deleting an object via AUTO_UPDATE

### DIFF
--- a/modelsearch/index.py
+++ b/modelsearch/index.py
@@ -209,6 +209,7 @@ def remove_object(instance):
         ):
             try:
                 backend.delete(indexed_instance)
+                backend.get_index_for_object(indexed_instance).refresh()
             except Exception:
                 # Log all errors
                 logger.exception(

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -1332,12 +1332,21 @@ class BackendTests:
                 # Transactions are active, so need to ensure they are committed before
                 # testing the search results
                 with self.captureOnCommitCallbacks(execute=True):
-                    models.Author.objects.create(name="Ernest Hemingway")
+                    author = models.Author.objects.create(name="Ernest Hemingway")
             else:
-                models.Author.objects.create(name="Ernest Hemingway")
+                author = models.Author.objects.create(name="Ernest Hemingway")
 
             results = self.backend.search("Ernest Hemingway", models.Author)
             self.assertEqual(results.count(), 1)
+
+            if isinstance(self, TestCase):
+                with self.captureOnCommitCallbacks(execute=True):
+                    author.delete()
+            else:
+                author.delete()
+
+            results = self.backend.search("Ernest Hemingway", models.Author)
+            self.assertEqual(results.count(), 0)
 
 
 @override_settings(


### PR DESCRIPTION
When AUTO_UPDATE is active, the desired behaviour is that database changes should immediately take effect on search results without the need to reindex. However, this is not the case if the index requires an explicit `refresh`, as Elasticsearch does. Fix this so that we call `refresh` during the signal handler.