### PR TITLE
Test against Django 4.2 and 6.0b1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,24 +31,64 @@ jobs:
         include:
           - database: sqlite
             backend: db
+            django-version: ">=4.2,<5.0"
+          - database: sqlite
+            backend: db
+            django-version: ">=5.2,<6.0"
+          - database: sqlite
+            backend: db
+            django-version: "==6.0b1"
           - database: postgresql
             backend: db
+            django-version: ">=4.2,<5.0"
+          - database: postgresql
+            backend: db
+            django-version: ">=5.2,<6.0"
+          - database: postgresql
+            backend: db
+            django-version: "==6.0b1"
           - database: mysql
             backend: db
+            django-version: ">=4.2,<5.0"
+          - database: mysql
+            backend: db
+            django-version: ">=5.2,<6.0"
+          - database: mysql
+            backend: db
+            django-version: "==6.0b1"
           - database: mariadb
             backend: db
+            django-version: ">=4.2,<5.0"
+          - database: mariadb
+            backend: db
+            django-version: ">=5.2,<6.0"
+          - database: mariadb
+            backend: db
+            django-version: "==6.0b1"
           - database: sqlite
             backend: elasticsearch7
+            django-version: ">=4.2,<5.0"
           - database: sqlite
             backend: elasticsearch8
+            django-version: ">=5.2,<6.0"
           - database: sqlite
             backend: elasticsearch9
+            django-version: ">=5.2,<6.0"
+          - database: sqlite
+            backend: elasticsearch9
+            django-version: "==6.0b1"
           - database: sqlite
             backend: opensearch2
             opensearch-version: 2.10.0
+            django-version: ">=4.2,<5.0"
           - database: sqlite
             backend: opensearch3
             opensearch-version: 3.1.0
+            django-version: ">=5.2,<6.0"
+          - database: sqlite
+            backend: opensearch3
+            opensearch-version: 3.1.0
+            django-version: "==6.0b1"
 
     services:
       postgresql:
@@ -171,6 +211,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install "Django${{ matrix.django-version }}"
           pip install .[test]
 
           if [[ "${{ matrix.backend }}" == "elasticsearch7" ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-  "Django (>5.0,<6)",
-  "django-tasks>=0.7,<0.9",
+  "Django>=4.2",
+  "django-tasks>=0.7,<0.10",
 ]
 description = "A library for indexing Django models with Elasicsearch, OpenSearch or database and searching them with the Django ORM."
 readme = "README.md"


### PR DESCRIPTION
I overlooked that modelsearch specifies Django >5.0, which is stricter than Wagtail's requirements of >=4.2 (4.2 is still in LTS for a few more months).

While we're at it, let's test against Django 6.0b1. 