### PR TITLE
Correctly handle hyphenated search terms on Postgres

### DIFF
--- a/modelsearch/backends/database/postgres/postgres.py
+++ b/modelsearch/backends/database/postgres/postgres.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 from collections import OrderedDict
@@ -384,7 +385,7 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
 
     def build_tsquery_content(self, query, config=None, invert=False):
         if isinstance(query, PlainText):
-            terms = query.query_string.split()
+            terms = re.split(r"[\s\-]+", query.query_string)
             if not terms:
                 return None
 

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -415,6 +415,24 @@ class BackendTests:
             ],
         )
 
+    def test_autocomplete_hyphenated_term(self):
+        book = models.Book.objects.create(
+            title="Poseidon-1234ABC",
+            number_of_pages=350,
+            publication_date=date(1961, 11, 10),
+        )
+        self.backend.add(book)
+        self.backend.get_index_for_model(models.Book).refresh()
+
+        results = self.backend.autocomplete("poseidon-1234", models.Book)
+
+        self.assertCountEqual(
+            [r.title for r in results],
+            [
+                "Poseidon-1234ABC",
+            ],
+        )
+
     # FILTERING TESTS
 
     def test_filter_exact_value(self):


### PR DESCRIPTION
Fixes #56

The Postgres `to_tsquery` function (used internally by `django.contrib.postgres.search` for SearchQuery) has a quirk/bug when passed a term such as 'poseidon-1234' - it treats this as two tokens 'poseidon' and '-1234', whereas 'poseidon-1234a' gives 'poseidon' and '1234a' which is consistent with how this text is indexed. To bypass this behaviour, treat `-` as a separator when handling PlainText query terms.