### PR TITLE
Avoid crash when indexing nullable reverse OneToOne relations

### DIFF
--- a/modelsearch/index.py
+++ b/modelsearch/index.py
@@ -337,6 +337,14 @@ class RelatedFields:
     def get_value(self, obj):
         field = self.get_field(obj.__class__)
 
+        if isinstance(field, OneToOneRel):
+            # Following a reverse one-to-one relation will raise a DoesNotExist exception if there is no related object;
+            # treat this as None instead
+            try:
+                return getattr(obj, self.field_name)
+            except field.related_model.DoesNotExist:
+                return None
+
         if isinstance(field, (RelatedField, ForeignObjectRel)):
             return getattr(obj, self.field_name)
 

--- a/modelsearch/test/testapp/models.py
+++ b/modelsearch/test/testapp/models.py
@@ -87,11 +87,22 @@ class Book(index.Indexed, models.Model):
         return novel or programming_guide or self
 
 
-class Character(models.Model):
+class Character(index.Indexed, models.Model):
     name = models.CharField(max_length=255)
     novel = models.ForeignKey(
         "Novel", related_name="characters", on_delete=models.CASCADE
     )
+
+    search_fields = [
+        index.SearchField("name"),
+        index.RelatedFields(
+            "novel_as_protagonist",
+            [
+                index.SearchField("title"),
+                index.FilterField("title"),
+            ],
+        ),
+    ]
 
     def __str__(self):
         return self.name
@@ -100,7 +111,10 @@ class Character(models.Model):
 class Novel(Book):
     setting = models.CharField(max_length=255)
     protagonist = models.OneToOneField(
-        Character, related_name="+", null=True, on_delete=models.SET_NULL
+        Character,
+        related_name="novel_as_protagonist",
+        null=True,
+        on_delete=models.SET_NULL,
     )
 
     search_fields = Book.search_fields + [

--- a/modelsearch/tests/elasticsearch_common_tests.py
+++ b/modelsearch/tests/elasticsearch_common_tests.py
@@ -260,6 +260,7 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
             [
                 "modelsearchtest_searchtests_author",
                 "modelsearchtest_searchtests_book",
+                "modelsearchtest_searchtests_character",
                 "modelsearchtest_searchtests_advertwithcustomuuidprimarykey",
                 "modelsearchtest_searchtests_meeting",
             ],

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -289,6 +289,17 @@ class BackendTests:
             ],
         )
 
+    def test_search_on_related_fields_reverse_one_to_one(self):
+        # "hobbit" is part of the search record for Bilbo Baggins via RelatedFields("novel_as_protagonist")
+        results = self.backend.search("hobbit", models.Character)
+
+        self.assertCountEqual(
+            [r.name for r in results],
+            [
+                "Bilbo Baggins",
+            ],
+        )
+
     def test_search_boosting_on_related_fields(self):
         # Bilbo Baggins is the protagonist of "The Hobbit" but not any of the "Lord of the Rings" novels.
         # As the protagonist has more boost than other characters, "The Hobbit" should always be returned

--- a/modelsearch/tests/test_db_backend.py
+++ b/modelsearch/tests/test_db_backend.py
@@ -48,6 +48,11 @@ class TestDBBackend(BackendTests, TestCase):
     def test_search_on_related_fields(self):
         super().test_search_on_related_fields()
 
+    # Doesn't support searching related fields
+    @unittest.expectedFailure
+    def test_search_on_related_fields_reverse_one_to_one(self):
+        super().test_search_on_related_fields_reverse_one_to_one()
+
     # Doesn't support searching callable fields
     @unittest.expectedFailure
     def test_search_callable_field(self):


### PR DESCRIPTION
Following a reverse OneToOne relation raises a RelatedObjectDoesNotExist exception if no related object exists. RelatedFields does not account for this during indexing, and so indexing will fail if any instance is not the target of this relation.

In the test models, this surfaces in the Novel.protagonist relation (because not all Characters are protagonists).