### PR TITLE
fixed TODO related to automatic template generation in MatchExpression class

### DIFF
--- a/modelsearch/backends/database/sqlite/query.py
+++ b/modelsearch/backends/database/sqlite/query.py
@@ -173,7 +173,6 @@ class CombinedSearchQueryExpression(SearchQueryCombinable, CombinedExpression):
 
 class MatchExpression(Expression):
     filterable = True
-    template = f"{SQLiteFTSIndexEntry._meta.db_table} MATCH %s"  # TODO: Can the table name be inferred from the query instead?
     output_field = BooleanField()
 
     def __init__(self, columns: list[str], query: SearchQueryCombinable) -> None:
@@ -182,6 +181,7 @@ class MatchExpression(Expression):
         self.query = query
 
     def as_sql(self, compiler, connection):
+        self.template = f"{compiler.query.base_table} MATCH %s"
         joined_columns = " ".join(
             self.columns
         )  # The format of the columns is 'column1 column2'

--- a/modelsearch/backends/database/sqlite/query.py
+++ b/modelsearch/backends/database/sqlite/query.py
@@ -181,7 +181,7 @@ class MatchExpression(Expression):
         self.query = query
 
     def as_sql(self, compiler, connection):
-        self.template = f"{compiler.query.base_table} MATCH %s"
+        template = f"{compiler.query.base_table} MATCH %s"
         joined_columns = " ".join(
             self.columns
         )  # The format of the columns is 'column1 column2'
@@ -192,7 +192,7 @@ class MatchExpression(Expression):
         params = [
             f"{{{joined_columns}}} : ({formatted_query})"
         ]  # Build the full MATCH search query. It will be a parameter to the template, so no SQL injections are possible here.
-        return (self.template, params)
+        return (template, params)
 
     def __repr__(self):
         return f"<MatchExpression: {self.columns!r} = {self.query!r}>"


### PR DESCRIPTION
fixed the todo in modelsearch\backends\database\sqlite\query.py regarding using pre defined template to building template dynamically using the query
i generated the template dynamically using the query in compiler which we get in input params in as_sql function

-importance: very low