### PR TITLE
Add warning regarding title field in index

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -48,6 +48,27 @@ class Person(index.Indexed, models.Model):
 
 This will make sure direct name matches will always out-rank mentions of the person in other people's biographies.
 
+## The `title` search field
+
+The field name `"title"` is special in Django ModelSearch. A `SearchField` named `"title"` populates the dedicated **title index column**, which is stored separately from the body content and is used to improve ranking quality.
+
+All other `SearchField` names populate the **body column**.
+
+If you omit `index.SearchField('title')` from your `search_fields`, the title column will be left empty, which degrades ranking quality for searches against that model. Django ModelSearch will emit a system check warning (`modelsearch.W005`) when this is the case.
+
+For example:
+
+```python
+class Article(index.Indexed, models.Model):
+    title = models.CharField(max_length=255)
+    body = models.TextField()
+
+    search_fields = [
+        index.SearchField('title'),  # populates the title index column
+        index.SearchField('body'),   # populates the body index column
+    ]
+```
+
 ## Indexing callables
 
 You can also pass callable methods to `index.SearchField` which can be helpful for cleaning up text for the search engine:

--- a/modelsearch/index.py
+++ b/modelsearch/index.py
@@ -184,6 +184,20 @@ class Indexed:
                         id="modelsearch.W004",
                     )
                 )
+        search_fields = cls.get_searchable_search_fields()
+        if search_fields and not any(f.field_name == "title" for f in search_fields):
+            errors.append(
+                checks.Warning(
+                    f"{cls.__name__}.search_fields does not contain a SearchField named 'title'. "
+                    "The title index column will be empty.",
+                    hint=(
+                        f"Add index.SearchField('title') to {cls.__name__}.search_fields to populate "
+                        "the title index column, which is used for ranking search results."
+                    ),
+                    obj=cls,
+                    id="modelsearch.W005",
+                )
+            )
         return errors
 
     search_fields = []

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from taggit.models import Tag
 
+from modelsearch import index
 from modelsearch.backends import (
     InvalidSearchBackendError,
     get_search_backend,
@@ -179,6 +180,79 @@ class BackendTests:
 
         # "JavaScript: The Definitive Guide" should be first
         self.assertEqual(results[0].title, "JavaScript: The Definitive Guide")
+
+    def test_ranking_reverse(self):
+        # Note: also tests the "or" operator
+        results = list(
+            self.backend.search("JavaScript good", models.Book, operator="or")
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            ["JavaScript: The good parts", "JavaScript: The Definitive Guide"],
+        )
+
+        self.assertEqual(results[0].title, "JavaScript: The good parts")
+
+    def test_ranking_degraded_without_title_search_field(self):
+        # When no SearchField named "title" is declared, the title index column
+        # is left empty. This is the root cause of ranking degradation: the
+        # per-backend title-column weighting and title_norm boost do not apply,
+        # so a term that only appears in a book's title can no longer rank that
+        # book above results that match on body content alone.
+        #
+        # We verify this by asserting that IndexEntry.title is empty for all
+        # Book entries after re-indexing with a search_fields configuration
+        # that contains SearchFields but none named "title".
+        search_fields_without_title = [
+            index.SearchField("summary", boost=2.0),
+            index.FilterField("title"),
+            index.FilterField("authors"),
+            index.RelatedFields("authors", models.Author.search_fields),
+            index.FilterField("publication_date"),
+            index.FilterField("number_of_pages"),
+        ]
+
+        from django.contrib.contenttypes.models import ContentType
+
+        old_search_fields = models.Book.search_fields
+        models.Book.search_fields = search_fields_without_title
+        try:
+            IndexEntry.objects.all().delete()
+            management.call_command(
+                "rebuild_modelsearch_index",
+                backend_name=self.backend_name,
+                stdout=StringIO(),
+                chunk_size=50,
+            )
+
+            # With no SearchField("title"), the title index column must be empty
+            # for every Book entry. An empty title column means title_norm has no
+            # effect and the backend cannot distinguish title-field matches from
+            # body-field matches, degrading ranking quality.
+            book_ct = ContentType.objects.get_for_model(models.Book)
+            book_entries = list(IndexEntry.objects.filter(content_type=book_ct))
+            self.assertGreater(len(book_entries), 0, "No Book index entries found")
+            for entry in book_entries:
+                self.assertEqual(
+                    entry.title,
+                    "",
+                    msg=(
+                        "Expected IndexEntry.title to be empty when no "
+                        f"SearchField('title') is declared, but got: {entry.title}"
+                    ),
+                )
+
+            # Confirm the contrast: with SearchField("title") present, the title
+            # column is non-empty and ranking works correctly (as test_ranking shows).
+        finally:
+            models.Book.search_fields = old_search_fields
+            IndexEntry.objects.all().delete()
+            management.call_command(
+                "rebuild_modelsearch_index",
+                backend_name=self.backend_name,
+                stdout=StringIO(),
+                chunk_size=50,
+            )
 
     def test_annotate_score(self):
         results = self.backend.search("JavaScript", models.Book).annotate_score(

--- a/modelsearch/tests/test_indexed_class.py
+++ b/modelsearch/tests/test_indexed_class.py
@@ -105,3 +105,19 @@ class TestSearchFields(TestCase):
             ]
             errors = models.Book.check()
             self.assertEqual(errors, expected_errors)
+
+    def test_checking_missing_title_search_field(self):
+        with patch_search_fields(models.Book, [index.SearchField("summary")]):
+            errors = models.Book.check()
+            w005_errors = [e for e in errors if e.id == "modelsearch.W005"]
+            self.assertEqual(len(w005_errors), 1)
+            self.assertIn("title", w005_errors[0].msg)
+
+    def test_no_warning_when_title_search_field_present(self):
+        with patch_search_fields(
+            models.Book,
+            [index.SearchField("title"), index.SearchField("summary")],
+        ):
+            errors = models.Book.check()
+            w005_errors = [e for e in errors if e.id == "modelsearch.W005"]
+            self.assertEqual(w005_errors, [])


### PR DESCRIPTION
# Add W005 warning when `SearchField("title")` is missing

## Summary

I noticed (accidentally) that `title` field name is special in Django ModelSearch: a `SearchField` named `"title"` populates a dedicated title index column used for ranking. If no such field is declared, the title column is silently left empty, degrading search quality with no indication to the developer.

This PR adds a system check warning (`modelsearch.W005`) that fires when a model defines at least one `SearchField` but none of them is named `"title"`.

I think this is a wagtail's legacy where title is always defined

## Example warning output

```
myapp.Article: (modelsearch.W005) Article.search_fields does not contain a SearchField named 'title'. The title index column will be empty.
    HINT: Add index.SearchField('title') to Article.search_fields to populate the title index column, which is used for ranking search results.
```