### PR TITLE
Fix 500 error when searching for words containing apostrophes

### DIFF
--- a/modelsearch/tests/test_queries.py
+++ b/modelsearch/tests/test_queries.py
@@ -225,6 +225,47 @@ class TestParseQueryString(SimpleTestCase):
             repr(Phrase("lord of the rings")),
         )
 
+    def test_apostrophe_in_word(self):
+        """
+        Searching for a word containing an apostrophe (e.g. "it's") should
+        be treated as a single PlainText query, not split into PlainText AND Phrase.
+        """
+        filters, query = parse_query_string("it's")
+
+        self.assertDictEqual(filters.dict(), {})
+        self.assertEqual(repr(query), repr(PlainText("it's")))
+
+    def test_apostrophe_as_phrase_delimiter(self):
+        """
+        Apostrophes used as phrase delimiters should still work.
+        e.g. 'hot cross bun' should be treated as a phrase.
+        """
+        filters, query = parse_query_string("'hot cross bun'")
+
+        self.assertDictEqual(filters.dict(), {})
+        self.assertEqual(repr(query), repr(Phrase("hot cross bun")))
+
+    def test_apostrophe_phrase_with_plain_text(self):
+        """
+        Mix of plain text and apostrophe phrase should still work.
+        """
+        filters, query = parse_query_string("recipe 'hot cross bun'")
+
+        self.assertDictEqual(filters.dict(), {})
+        self.assertEqual(
+            repr(query),
+            repr(And([PlainText("recipe"), Phrase("hot cross bun")]))
+        )
+
+    def test_multiple_apostrophes_in_words(self):
+        """
+        Multiple mid-word apostrophes should all be handled correctly.
+        """
+        filters, query = parse_query_string("it's don't")
+
+        self.assertDictEqual(filters.dict(), {})
+        self.assertEqual(repr(query), repr(PlainText("it's don't")))
+
 
 class TestBalancedReduce(SimpleTestCase):
     # For simple values, this should behave exactly the same as Pythons reduce()

--- a/modelsearch/utils.py
+++ b/modelsearch/utils.py
@@ -118,8 +118,10 @@ def parse_query_string(query_string, operator=None, zero_terms=MATCH_NONE):
     tokens = []
     if '"' in query_string:
         parts = query_string.split('"')
+    elif re.search(r"(?<!\w)'|'(?!\w)", query_string):
+        parts = re.split(r"(?<!\w)'|'(?!\w)", query_string)
     else:
-        parts = query_string.split("'")
+        parts = [query_string]
 
     for part in parts:
         part = part.strip()


### PR DESCRIPTION
Fixes wagtail/wagtail#13956

### Description
When searching for words containing apostrophes (e.g. `it's`) in the Wagtail 
admin sidebar search with Elasticsearch, a 500 error was raised with 
`NotImplementedError: 'And' is not supported for autocomplete queries`.

`parse_query_string` was splitting on all apostrophes, treating `it's` as 
`And(PlainText('it'), Phrase('s'))`. The Elasticsearch autocomplete backend 
does not support `And` queries.

The fix updates `parse_query_string` to only split on apostrophes that are 
NOT inside a word, using regex lookahead and lookbehind. Mid-word apostrophes 
like `it's` are now treated as plain text.

