### PR TITLE
Short-circuit queries with empty field lists

### DIFF
--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -751,8 +751,8 @@ class BaseSearchBackend:
 
         - Normalises the ``model_or_queryset`` parameter into a queryset, using ``model.objects.all()`` if a model class
           is provided.
-        - Short-circuits the query compiler if the model is not indexed or the query is an empty string, returning an
-          empty result set in these cases.
+        - Short-circuits the query compiler if the model is not indexed, the query is an empty string, or the fields list is
+          empty, returning an empty result set in these cases.
         - Instantiates the query compiler with the queryset, query string, and any additional keyword arguments.
         - Calls ``check()`` on the query compiler to validate the query.
         - Returns a ``results_class`` instance, passing in the backend and the query compiler.
@@ -776,6 +776,10 @@ class BaseSearchBackend:
 
         # Check that there's still a query string after the clean up
         if query == "":
+            return EmptySearchResults()
+
+        # Check that the `fields` parameter is not an empty list
+        if kwargs.get("fields") is not None and len(kwargs["fields"]) == 0:
             return EmptySearchResults()
 
         # Search

--- a/modelsearch/backends/elasticsearchbase.py
+++ b/modelsearch/backends/elasticsearchbase.py
@@ -768,14 +768,7 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
             )
 
     def get_inner_query(self):
-        if self.remapped_fields:
-            fields = self.remapped_fields
-        else:
-            fields = ["_all_text"]
-
-        if len(fields) == 0:
-            # No fields. Return a query that'll match nothing
-            return {"bool": {"must_not": {"match_all": {}}}}
+        fields = self.remapped_fields
 
         # Handle MatchAll and PlainText separately as they were supported
         # before "search query classes" was implemented and we'd like to

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -257,6 +257,16 @@ class BackendTests:
 
         self.assertCountEqual([r.title for r in results], ["The Hobbit"])
 
+    def test_search_on_no_fields(self):
+        # fields=[] should return no results
+        results = self.backend.search(
+            "hobbit",
+            models.Book,
+            fields=[],
+        )
+
+        self.assertCountEqual([r.title for r in results], [])
+
     def test_search_on_unknown_field(self):
         with self.assertRaises(FieldError):
             list(


### PR DESCRIPTION
`ElasticsearchBaseSearchQueryCompiler.get_inner_query` had some logic for handling an empty `fields` list that could never have worked given that `_remap_fields` will always return a non-empty list (unless `fields` contained only invalid fields, which is caught elsewhere). A better place for this check is `BaseSearchBackend._search`, which already has cases for returning empty results if the model is not `Indexed` or the query is blank.