### PR TITLE
Support filtering on related fields

### DIFF
--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -86,11 +86,12 @@ class BaseSearchQueryCompiler:
 
         return field
 
-    def _get_filter_field_for_column(self, column):
+    def _get_filter_field_path_for_column(self, column):
         """
         Given a `django.db.models.expressions.Col` instance representing a field being filtered on -
-        potentially spanning one or more relations - returns the corresponding `index.FilterField`
-        instance for that field, or `None` if there isn't one.
+        potentially spanning one or more relations - return the list of search_fields definitions
+        leading to that field, consisting of zero or more `RelatedFields` definitions followed by a
+        `FilterField` instance. If no such path exists, raise a FilterFieldError.
         """
         # Get the list of aliases for the joined tables linking column.alias (i.e. the table containing
         # the column we're filtering on) back to the base table.
@@ -111,6 +112,9 @@ class BaseSearchQueryCompiler:
         # The search_fields definition for the table currently under consideration. Initially this is the base model's
         # search_fields list, but as we follow the chain of joins we may descend into RelatedFields definitions.
         search_fields = model.get_search_fields()
+
+        # The sequence of search_fields definitions followed so far.
+        path = []
 
         while table_aliases:
             # Inspect the next join in the chain
@@ -148,6 +152,7 @@ class BaseSearchQueryCompiler:
                         # update `model` and `search_fields` to descend into this RelatedFields definition.
                         model = field.related_model
                         search_fields = search_field.fields
+                        path.append(search_field)
                         break
 
                     if (
@@ -162,11 +167,16 @@ class BaseSearchQueryCompiler:
                                 table_aliases.pop()
                                 model = field.related_model
                                 search_fields = search_field.fields
+                                path.append(search_field)
                                 break
 
                 else:
                     # no matching RelatedFields entry found
-                    return None
+                    field_attname = column.target.attname
+                    raise FilterFieldError(
+                        f'Cannot filter search results with field "{field_attname}". Please add a suitable index.RelatedFields definition to {self.queryset.model.__name__}.search_fields.',
+                        field_name=field_attname,
+                    )
 
         # All joins have now been traversed, and `model` and `search_fields` now correspond to the table being filtered on.
         # Look for a FilterField entry for the column in this search_fields list.
@@ -175,7 +185,20 @@ class BaseSearchQueryCompiler:
                 isinstance(search_field, FilterField)
                 and search_field.get_attname(model) == column.target.attname
             ):
-                return search_field
+                path.append(search_field)
+                return path
+        else:
+            field_attname = column.target.attname
+            if path:
+                # The missing FilterField is somewhere in a (possibly nested) RelatedFields record. Mentioning the deepest-nested one
+                # in the error message should hopefully be sufficient for the developer to identify it...
+                message = f'Cannot filter search results with field "{field_attname}". Please add index.FilterField("{field_attname}") to the RelatedFields("{path[-1].field_name}") definition in {self.queryset.model.__name__}.search_fields.'
+            else:
+                message = f'Cannot filter search results with field "{field_attname}". Please add index.FilterField("{field_attname}") to {self.queryset.model.__name__}.search_fields.'
+            raise FilterFieldError(
+                message,
+                field_name=field_attname,
+            )
 
     def _process_lookup(self, field, lookup, value):
         """
@@ -209,14 +232,8 @@ class BaseSearchQueryCompiler:
 
     def _process_filter(self, column, lookup, value, check_only=False):
         # Get the field
-        field = self._get_filter_field_for_column(column)
-
-        if field is None:
-            field_attname = column.target.attname
-            raise FilterFieldError(
-                f'Cannot filter search results with field "{field_attname}". Please add index.FilterField("{field_attname}") to {self.queryset.model.__name__}.search_fields.',
-                field_name=field_attname,
-            )
+        field_path = self._get_filter_field_path_for_column(column)
+        field = field_path[-1]
 
         # Process the lookup
         if not check_only:

--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -9,7 +9,12 @@ from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.where import NothingNode, WhereNode
 
-from modelsearch.index import class_is_indexed, get_indexed_models
+from modelsearch.index import (
+    FilterField,
+    RelatedFields,
+    class_is_indexed,
+    get_indexed_models,
+)
 from modelsearch.query import MATCH_ALL, PlainText
 
 
@@ -81,6 +86,97 @@ class BaseSearchQueryCompiler:
 
         return field
 
+    def _get_filter_field_for_column(self, column):
+        """
+        Given a `django.db.models.expressions.Col` instance representing a field being filtered on -
+        potentially spanning one or more relations - returns the corresponding `index.FilterField`
+        instance for that field, or `None` if there isn't one.
+        """
+        # Get the list of aliases for the joined tables linking column.alias (i.e. the table containing
+        # the column we're filtering on) back to the base table.
+        next_alias = column.alias
+        table_aliases = []
+        while next_alias is not None:
+            table_aliases.append(next_alias)
+            next_alias = self.queryset.query.alias_map[next_alias].parent_alias
+
+        # Remove the base table from the list; this corresponds to the base model of the queryset.
+        # All remaining aliases in the list are joins.
+        table_aliases.pop()
+
+        # The model corresponding to the table currently under consideration. We keep track of this so that we can call
+        # search_field.get_field(model) to retrieve the corresponding Django model field.
+        model = self.queryset.model
+
+        # The search_fields definition for the table currently under consideration. Initially this is the base model's
+        # search_fields list, but as we follow the chain of joins we may descend into RelatedFields definitions.
+        search_fields = model.get_search_fields()
+
+        while table_aliases:
+            # Inspect the next join in the chain
+            table_alias = table_aliases.pop()
+            table = self.queryset.query.alias_map[table_alias]
+            join_field = table.join_field
+
+            if join_field.one_to_one and getattr(
+                join_field.remote_field, "parent_link", False
+            ):
+                # This is a join to a parent model in a multi-table inheritance setup.
+                #
+                # Example 1: `Restaurant.objects.filter(name="Pizza Hut")` where name is a field on Restaurant's parent model Place.
+                # Here, the base table is Restaurant, and we are joining to the Place table to access the `name` field.
+                # However, the ORM presents this as if it were a field of Restaurant, and thus we expect to find FilterField("name")
+                # in Restaurant.search_fields - not nested inside a RelatedFields entry as we would for other kinds of relation.
+                # Our search_fields pointer is therefore unchanged in this step.
+
+                # Example 2: `Character.objects.filter(novel__title="The Lord of the Rings")` where title is a field on Novel's parent model Book.
+                # In the first iteration we have followed the relation from Character to Novel; `model` is now Novel and `search_fields` is the
+                # list of fields within RelatedFields("novel") in Character's search_fields. We are now handling the join to the Book model to
+                # access the `title` field - again, this step does not change `search_fields`, as we still expect to find FilterField("title")
+                # in the RelatedFields("novel") list.
+                pass
+            else:
+                # This join corresponds to a relation such as a ForeignKey or ManyToManyField -
+                # look for a RelatedFields entry in search_fields that corresponds to this relation.
+                for search_field in search_fields:
+                    if not isinstance(search_field, RelatedFields):
+                        continue
+
+                    field = search_field.get_field(model)
+                    if field == join_field:
+                        # This RelatedFields entry corresponds to the join we're following -
+                        # update `model` and `search_fields` to descend into this RelatedFields definition.
+                        model = field.related_model
+                        search_fields = search_field.fields
+                        break
+
+                    if (
+                        field.many_to_many
+                        and field.path_infos[0].join_field == join_field
+                    ):
+                        # This join matches the first half of the M2M relation referenced by this RelatedFields entry -
+                        # if the next join matches the second half, consume them both and descend into this RelatedFields definition.
+                        if table_aliases:
+                            table2 = self.queryset.query.alias_map[table_aliases[-1]]
+                            if table2.join_field == field.path_infos[1].join_field:
+                                table_aliases.pop()
+                                model = field.related_model
+                                search_fields = search_field.fields
+                                break
+
+                else:
+                    # no matching RelatedFields entry found
+                    return None
+
+        # All joins have now been traversed, and `model` and `search_fields` now correspond to the table being filtered on.
+        # Look for a FilterField entry for the column in this search_fields list.
+        for search_field in search_fields:
+            if (
+                isinstance(search_field, FilterField)
+                and search_field.get_attname(model) == column.target.attname
+            ):
+                return search_field
+
     def _process_lookup(self, field, lookup, value):
         """
         To be implemented by subclasses if they wish to call ``_get_filters_from_queryset`` with
@@ -111,11 +207,12 @@ class BaseSearchQueryCompiler:
         """
         raise NotImplementedError
 
-    def _process_filter(self, field_attname, lookup, value, check_only=False):
+    def _process_filter(self, column, lookup, value, check_only=False):
         # Get the field
-        field = self._get_filterable_field(field_attname)
+        field = self._get_filter_field_for_column(column)
 
         if field is None:
+            field_attname = column.target.attname
             raise FilterFieldError(
                 f'Cannot filter search results with field "{field_attname}". Please add index.FilterField("{field_attname}") to {self.queryset.model.__name__}.search_fields.',
                 field_name=field_attname,
@@ -126,6 +223,7 @@ class BaseSearchQueryCompiler:
             result = self._process_lookup(field, lookup, value)
 
             if result is None:
+                field_attname = column.target.attname
                 raise FilterError(
                     f'Could not apply filter on search results: "{field_attname}__{lookup} = {value}". Lookup "{lookup}" not recognised.'
                 )
@@ -151,7 +249,7 @@ class BaseSearchQueryCompiler:
                         f'Cannot apply filter on search results: "{where_node.lhs.lookup_name}" queries are not supported.'
                     )
                 else:
-                    field_attname = where_node.lhs.lhs.target.attname
+                    column = where_node.lhs.lhs
                     lookup = where_node.lookup_name
                     if lookup == "gte":
                         # filter on year(date) >= value
@@ -175,13 +273,13 @@ class BaseSearchQueryCompiler:
                         # filter on year(date) == value
                         # i.e. date >= Jan 1st of that year and date < Jan 1st of the next year
                         filter1 = self._process_filter(
-                            field_attname,
+                            column,
                             "gte",
                             datetime.date(int(where_node.rhs), 1, 1),
                             check_only=check_only,
                         )
                         filter2 = self._process_filter(
-                            field_attname,
+                            column,
                             "lt",
                             datetime.date(int(where_node.rhs) + 1, 1, 1),
                             check_only=check_only,
@@ -197,18 +295,16 @@ class BaseSearchQueryCompiler:
                             f'Cannot apply filter on search results: "{where_node.lhs.lookup_name}" queries are not supported.'
                         )
             else:
-                field_attname = where_node.lhs.target.attname
+                column = where_node.lhs
                 lookup = where_node.lookup_name
                 value = where_node.rhs
 
             # Ignore pointer fields that show up in specific page type queries
-            if field_attname.endswith("_ptr_id"):
+            if column.target.attname.endswith("_ptr_id"):
                 return
 
             # Process the filter
-            return self._process_filter(
-                field_attname, lookup, value, check_only=check_only
-            )
+            return self._process_filter(column, lookup, value, check_only=check_only)
 
         elif isinstance(where_node, NothingNode):
             if check_only:

--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -200,13 +200,14 @@ class BaseSearchQueryCompiler:
                 field_name=field_attname,
             )
 
-    def _process_lookup(self, field, lookup, value):
+    def _process_lookup(self, field_path, lookup, value):
         """
         To be implemented by subclasses if they wish to call ``_get_filters_from_queryset`` with
         ``check_only=False``. Returns the data structure corresponding to a filter lookup on an
         individual field.
 
-        :param field: The ``FilterField`` instance for the field being filtered on.
+        :param field_path: The list of ``search_fields`` definitions leading to the ``FilterField`` instance
+        for the field being filtered on, consisting of zero or more ``RelatedFields`` definitions followed by the ``FilterField``.
         :param lookup: The identifier for the type of lookup being performed, such as ``"exact"`` or ``"lt"``.
         :param value: The lookup value.
         """
@@ -233,11 +234,10 @@ class BaseSearchQueryCompiler:
     def _process_filter(self, column, lookup, value, check_only=False):
         # Get the field
         field_path = self._get_filter_field_path_for_column(column)
-        field = field_path[-1]
 
         # Process the lookup
         if not check_only:
-            result = self._process_lookup(field, lookup, value)
+            result = self._process_lookup(field_path, lookup, value)
 
             if result is None:
                 field_attname = column.target.attname

--- a/modelsearch/backends/elasticsearchbase.py
+++ b/modelsearch/backends/elasticsearchbase.py
@@ -522,8 +522,34 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
 
         return remapped_fields
 
-    def _process_lookup(self, field, lookup, value):
-        column_name = self.mapping.get_field_column_name(field)
+    def _process_lookup(
+        self, field_path, lookup, value, mapping=None, column_name_prefix=""
+    ):
+        if mapping is None:
+            mapping = self.mapping
+
+        field = field_path[0]
+        if isinstance(field, RelatedFields):
+            # Get the lookup for the next field in the path, and wrap it in a {"nested": ...} query
+            related_column_name = mapping.get_field_column_name(field)
+            related_column_name_prefix = column_name_prefix + related_column_name + "."
+            related_model = field.get_field(mapping.model).related_model
+            related_mapping = self.mapping_class(related_model)
+            nested_query = self._process_lookup(
+                field_path[1:],
+                lookup,
+                value,
+                mapping=related_mapping,
+                column_name_prefix=related_column_name_prefix,
+            )
+            return {
+                "nested": {
+                    "path": related_column_name,
+                    "query": nested_query,
+                }
+            }
+
+        column_name = column_name_prefix + mapping.get_field_column_name(field)
 
         if lookup == "exact":
             if isinstance(value, (Query, Subquery)):
@@ -536,7 +562,7 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
 
             return {
                 "term": {
-                    column_name: self.mapping._clean_value(value),
+                    column_name: mapping._clean_value(value),
                 }
             }
 
@@ -555,7 +581,7 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
         if lookup in ["startswith", "prefix"]:
             return {
                 "prefix": {
-                    column_name: self.mapping._clean_value(value),
+                    column_name: mapping._clean_value(value),
                 }
             }
 
@@ -563,7 +589,7 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
             return {
                 "range": {
                     column_name: {
-                        lookup: self.mapping._clean_value(value),
+                        lookup: mapping._clean_value(value),
                     }
                 }
             }
@@ -574,8 +600,8 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
             return {
                 "range": {
                     column_name: {
-                        "gte": self.mapping._clean_value(lower),
-                        "lte": self.mapping._clean_value(upper),
+                        "gte": mapping._clean_value(lower),
+                        "lte": mapping._clean_value(upper),
                     }
                 }
             }
@@ -591,7 +617,7 @@ class ElasticsearchBaseSearchQueryCompiler(BaseSearchQueryCompiler):
                 value = list(value)
             return {
                 "terms": {
-                    column_name: [self.mapping._clean_value(val) for val in value],
+                    column_name: [mapping._clean_value(val) for val in value],
                 }
             }
 

--- a/modelsearch/test/testapp/models.py
+++ b/modelsearch/test/testapp/models.py
@@ -21,6 +21,7 @@ class Author(index.Indexed, models.Model):
             "books",
             [
                 index.FilterField("publication_date"),
+                index.FilterField("number_of_pages"),
             ],
         ),
     ]

--- a/modelsearch/test/testapp/models.py
+++ b/modelsearch/test/testapp/models.py
@@ -17,6 +17,12 @@ class Author(index.Indexed, models.Model):
         index.SearchField("name"),
         index.AutocompleteField("name"),
         index.FilterField("date_of_birth"),
+        index.RelatedFields(
+            "books",
+            [
+                index.FilterField("publication_date"),
+            ],
+        ),
     ]
 
     def __str__(self):
@@ -41,7 +47,14 @@ class Book(index.Indexed, models.Model):
         index.AutocompleteField("title"),
         index.FilterField("title"),
         index.FilterField("authors"),
-        index.RelatedFields("authors", Author.search_fields),
+        index.RelatedFields(
+            "authors",
+            [
+                index.SearchField("name"),
+                index.AutocompleteField("name"),
+                index.FilterField("date_of_birth"),
+            ],
+        ),
         index.FilterField("publication_date"),
         index.FilterField("number_of_pages"),
         index.RelatedFields(
@@ -102,6 +115,13 @@ class Character(index.Indexed, models.Model):
                 index.FilterField("title"),
             ],
         ),
+        index.RelatedFields(
+            "novel",
+            [
+                index.FilterField("setting"),
+                index.FilterField("publication_date"),
+            ],
+        ),
     ]
 
     def __str__(self):
@@ -124,12 +144,14 @@ class Novel(Book):
             "characters",
             [
                 index.SearchField("name", boost=0.25),
+                index.FilterField("name"),
             ],
         ),
         index.RelatedFields(
             "protagonist",
             [
                 index.SearchField("name", boost=0.5),
+                index.FilterField("name"),
                 index.FilterField("novel"),
             ],
         ),

--- a/modelsearch/tests/elasticsearch_common_tests.py
+++ b/modelsearch/tests/elasticsearch_common_tests.py
@@ -280,3 +280,27 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
     @unittest.expectedFailure  # Elasticsearch does not support ORDER BY expressions
     def test_order_by_expression(self):
         return super().test_order_by_expression()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_one_to_many(self):
+        return super().test_filter_on_related_fields_one_to_many()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_foreign_key(self):
+        return super().test_filter_on_related_fields_foreign_key()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_one_to_one(self):
+        return super().test_filter_on_related_fields_one_to_one()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_reverse_one_to_one(self):
+        return super().test_filter_on_related_fields_reverse_one_to_one()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_forward_many_to_many(self):
+        return super().test_filter_on_related_fields_forward_many_to_many()
+
+    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
+    def test_filter_on_related_fields_reverse_many_to_many(self):
+        return super().test_filter_on_related_fields_reverse_many_to_many()

--- a/modelsearch/tests/elasticsearch_common_tests.py
+++ b/modelsearch/tests/elasticsearch_common_tests.py
@@ -280,27 +280,3 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
     @unittest.expectedFailure  # Elasticsearch does not support ORDER BY expressions
     def test_order_by_expression(self):
         return super().test_order_by_expression()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_one_to_many(self):
-        return super().test_filter_on_related_fields_one_to_many()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_foreign_key(self):
-        return super().test_filter_on_related_fields_foreign_key()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_one_to_one(self):
-        return super().test_filter_on_related_fields_one_to_one()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_reverse_one_to_one(self):
-        return super().test_filter_on_related_fields_reverse_one_to_one()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_forward_many_to_many(self):
-        return super().test_filter_on_related_fields_forward_many_to_many()
-
-    @unittest.expectedFailure  # Filtering on related fields is not yet implemented for Elasticsearch
-    def test_filter_on_related_fields_reverse_many_to_many(self):
-        return super().test_filter_on_related_fields_reverse_many_to_many()

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -917,6 +917,36 @@ class BackendTests:
             [],
         )
 
+    def test_multiple_filters_on_related_fields(self):
+        results = list(
+            self.backend.search(
+                "tolkien",
+                models.Author.objects.filter(
+                    books__publication_date=date(1954, 7, 29),
+                    books__number_of_pages__gt=400,
+                ),
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            ["J. R. R. Tolkien"],
+        )
+        results = list(
+            self.backend.search(
+                "tolkien",
+                models.Author.objects.filter(
+                    # There is no single book that matches both of these criteria, so no results should be returned
+                    # (even though there are matches for the individual criteria)
+                    books__publication_date=date(1954, 7, 29),
+                    books__number_of_pages__lt=400,
+                ),
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            [],
+        )
+
     def test_missing_filter_field(self):
         with self.assertRaisesMessage(
             FilterFieldError,

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -796,6 +796,127 @@ class BackendTests:
         )
         self.assertEqual(set(results), {learning_python})
 
+    def test_filter_on_related_fields_one_to_many(self):
+        results = list(
+            self.backend.search(
+                "king", models.Novel.objects.filter(characters__name="Frodo Baggins")
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            ["The Return of the King"],
+        )
+
+        results = list(
+            self.backend.search(
+                "thrones", models.Novel.objects.filter(characters__name="Frodo Baggins")
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            [],
+        )
+
+    def test_filter_on_related_fields_foreign_key(self):
+        results = list(
+            self.backend.search(
+                "thorin", models.Character.objects.filter(novel__setting="Middle Earth")
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            ["Thorin Oakenshield"],
+        )
+
+        results = list(
+            self.backend.search(
+                "thorin", models.Character.objects.filter(novel__setting="Westeros")
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            [],
+        )
+
+    def test_filter_on_related_fields_one_to_one(self):
+        results = list(
+            self.backend.search(
+                "hobbit", models.Novel.objects.filter(protagonist__name="Bilbo Baggins")
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            ["The Hobbit"],
+        )
+
+        results = list(
+            self.backend.search(
+                "hobbit", models.Novel.objects.filter(protagonist__name="Frodo Baggins")
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            [],
+        )
+
+    def test_filter_on_related_fields_reverse_one_to_one(self):
+        results = list(
+            self.backend.search(
+                "baggins",
+                models.Character.objects.filter(
+                    novel_as_protagonist__title="The Hobbit"
+                ),
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            ["Bilbo Baggins"],
+        )
+
+    def test_filter_on_related_fields_forward_many_to_many(self):
+        results = list(
+            self.backend.search(
+                "hobbit",
+                models.Book.objects.filter(authors__date_of_birth=date(1892, 1, 3)),
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            ["The Hobbit"],
+        )
+        results = list(
+            self.backend.search(
+                "hobbit",
+                models.Book.objects.filter(authors__date_of_birth=date(1920, 1, 2)),
+            )
+        )
+        self.assertCountEqual(
+            [r.title for r in results],
+            [],
+        )
+
+    def test_filter_on_related_fields_reverse_many_to_many(self):
+        results = list(
+            self.backend.search(
+                "tolkien",
+                models.Author.objects.filter(books__publication_date=date(1954, 7, 29)),
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            ["J. R. R. Tolkien"],
+        )
+        results = list(
+            self.backend.search(
+                "tolkien",
+                models.Author.objects.filter(books__publication_date=date(2000, 1, 1)),
+            )
+        )
+        self.assertCountEqual(
+            [r.name for r in results],
+            [],
+        )
+
     # ORDER BY RELEVANCE
 
     def test_order_by_relevance_match_all(self):

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -917,6 +917,45 @@ class BackendTests:
             [],
         )
 
+    def test_missing_filter_field(self):
+        with self.assertRaisesMessage(
+            FilterFieldError,
+            'Cannot filter search results with field "name". Please add index.FilterField("name") to Author.search_fields.',
+        ):
+            list(
+                self.backend.search(
+                    MATCH_ALL, models.Author.objects.filter(name="Isaac Asimov")
+                )
+            )
+
+    def test_missing_filter_field_in_related_fields(self):
+        with self.assertRaisesMessage(
+            FilterFieldError,
+            'Cannot filter search results with field "publication_date". Please add index.FilterField("publication_date") to the RelatedFields("novel_as_protagonist") definition in Character.search_fields.',
+        ):
+            list(
+                self.backend.search(
+                    MATCH_ALL,
+                    models.Character.objects.filter(
+                        novel_as_protagonist__publication_date=date(1937, 9, 21)
+                    ),
+                )
+            )
+
+    def test_missing_related_fields(self):
+        with self.assertRaisesMessage(
+            FilterFieldError,
+            'Cannot filter search results with field "name". Please add a suitable index.RelatedFields definition to Character.search_fields.',
+        ):
+            list(
+                self.backend.search(
+                    MATCH_ALL,
+                    models.Character.objects.filter(
+                        novel__authors__name="J. R. R. Tolkien"
+                    ),
+                )
+            )
+
     # ORDER BY RELEVANCE
 
     def test_order_by_relevance_match_all(self):

--- a/modelsearch/tests/test_elasticsearch7_backend.py
+++ b/modelsearch/tests/test_elasticsearch7_backend.py
@@ -1247,6 +1247,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                             "type": "text",
                             "copy_to": ["_all_text", "_all_text_boost_0_5"],
                         },
+                        "name_filter": {"type": "keyword"},
                         "novel_id_filter": {"type": "integer"},
                     },
                 },
@@ -1258,6 +1259,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                             "type": "text",
                             "copy_to": ["_all_text", "_all_text_boost_0_25"],
                         },
+                        "name_filter": {"type": "keyword"},
                     },
                 },
                 # Inherited
@@ -1340,13 +1342,14 @@ class TestElasticsearch7MappingInheritance(TestCase):
             "searchtests_novel__setting_edgengrams": "Middle Earth",
             "searchtests_novel__protagonist": {
                 "name": "Frodo Baggins",
+                "name_filter": "Frodo Baggins",
                 "novel_id_filter": 4,
             },
             "searchtests_novel__protagonist_id_filter": 8,
             "searchtests_novel__characters": [
-                {"name": "Bilbo Baggins"},
-                {"name": "Frodo Baggins"},
-                {"name": "Gandalf"},
+                {"name": "Bilbo Baggins", "name_filter": "Bilbo Baggins"},
+                {"name": "Frodo Baggins", "name_filter": "Frodo Baggins"},
+                {"name": "Gandalf", "name_filter": "Gandalf"},
             ],
             # Changed
             "_django_content_type": ["searchtests.Novel", "searchtests.Book"],


### PR DESCRIPTION
Fixes #12

Fix the validation phase of `BaseSearchQueryCompiler._process_filter` so that it correctly descends into `RelatedFields` definitions when confirming that a field being filtered on has a corresponding `FilterField`. (Previously it only looked in the `search_fields` definition of the base model of the query, giving spurious "Please add index.FilterField" errors.) This is sufficient to make filtering by related fields work for the database search backends (because these work by annotating and filtering the original query, retaining all existing filtering logic).

For Elasticsearch-based engines, we also need to rewrite the filter clause into Elasticsearch query syntax: where a filter on a field of the base model looks like:

    {"term": {"number_of_pages_filter": 320}}

the equivalent for a field on a related model is:

    {"nested": {
      "path": "authors",
      "query": {"term": {"authors.date_of_birth_filter": "1892-01-03"}}
    }}

To achieve this, we revise the API of `_process_lookup` (which is only implemented by the Elasticsearch backends) so that it receives the full chain of `RelatedFields` definitions leading up to the `FilterField` being filtered on, and accepts a `mapping` parameter so that it can work with the mapping of any model (rather than just `self.mapping` which is tied to the query's root model). We can then call `_process_lookup` recursively to build the inner `{"term": ...}` clause, and wrap it in the `{"nested": ...}` clause.