### PR TITLE
delay import of signal handlers until app is ready

### DIFF
--- a/modelsearch/apps.py
+++ b/modelsearch/apps.py
@@ -3,8 +3,6 @@ from django.conf import settings
 from django.core.checks import Tags, Warning, register
 from django.db import connection
 
-from modelsearch.signal_handlers import register_signal_handlers
-
 
 class ModelSearchAppConfig(AppConfig):
     name = "modelsearch"
@@ -14,6 +12,7 @@ class ModelSearchAppConfig(AppConfig):
     backend_setting_name = "MODELSEARCH_BACKENDS"
 
     def ready(self):
+        from modelsearch.signal_handlers import register_signal_handlers
         register_signal_handlers()
 
         if connection.vendor == "postgresql":


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #80

### Description

<!-- Please describe the problem you're fixing. -->
This solves the issue of an `AppRegistryNotReady("Apps aren't loaded yet.")` exception when using `django_tasks.backends.database.DatabaseBackend` as the default `TASKS` backend with `wagtail`.

Task configuration:

Installed apps:

```
INSTALLED_APPS = [
    # ...
    "wagtail.search",
    "django_tasks",
    "django_tasks.backends.database",
    # ...
]
```

```
TASKS = {
    "default": {
        "BACKEND": "django_tasks.backends.database.DatabaseBackend",
    }
}
```

Trying to run a migration or start the `db_worker` script results in the following error:

```
Traceback (most recent call last):
  File "../manage.py", line 23, in <module>
    main()
    ~~~~^^
  File "../manage.py", line 19, in main
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "../.venv/lib/python3.14/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "../.venv/lib/python3.14/site-packages/django/core/management/__init__.py", line 417, in execute
    django.setup()
    ~~~~~~~~~~~~^^
  File "../.venv/lib/python3.14/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "../.venv/lib/python3.14/site-packages/django/apps/registry.py", line 91, in populate
    app_config = AppConfig.create(entry)
  File "../.venv/lib/python3.14/site-packages/django/apps/config.py", line 123, in create
    mod = import_module(mod_path)
  File "/Users/thomas/.pyenv/versions/3.14.2/lib/python3.14/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1398, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1371, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1342, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 938, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 759, in exec_module
  File "<frozen importlib._bootstrap>", line 491, in _call_with_frames_removed
  File "../.venv/lib/python3.14/site-packages/modelsearch/apps.py", line 6, in <module>
    from modelsearch.signal_handlers import register_signal_handlers
  File "../.venv/lib/python3.14/site-packages/modelsearch/signal_handlers.py", line 4, in <module>
    from .tasks import insert_or_update_object_task
  File "../.venv/lib/python3.14/site-packages/modelsearch/tasks.py", line 7, in <module>
    @task()
     ~~~~^^
  File "../.venv/lib/python3.14/site-packages/django_tasks/base.py", line 235, in wrapper
    return task_backends[backend].task_class(
           ~~~~~~~~~~~~~^^^^^^^^^
  File "../.venv/lib/python3.14/site-packages/django/utils/connection.py", line 62, in __getitem__
    conn = self.create_connection(alias)
  File "../.venv/lib/python3.14/site-packages/django_tasks/__init__.py", line 72, in create_connection
    return backend_cls(alias=alias, params=params)  # type:ignore[no-any-return]
  File "../.venv/lib/python3.14/site-packages/django_tasks/backends/database/backend.py", line 40, in __init__
    from .models import DBTaskResult
  File "../.venv/lib/python3.14/site-packages/django_tasks/backends/database/models.py", line 95, in <module>
    class DBTaskResult(GenericBase[P, T], models.Model):
    ...<179 lines>...
            )
  File "../.venv/lib/python3.14/site-packages/django/db/models/base.py", line 131, in __new__
    app_config = apps.get_containing_app_config(module)
  File "../.venv/lib/python3.14/site-packages/django/apps/registry.py", line 260, in get_containing_app_config
    self.check_apps_ready()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "../.venv/lib/python3.14/site-packages/django/apps/registry.py", line 138, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
None