### PR TITLE
Correctly handle trailing hyphens in Postgres search

### DIFF
--- a/modelsearch/backends/database/postgres/postgres.py
+++ b/modelsearch/backends/database/postgres/postgres.py
@@ -522,7 +522,7 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
 
     def build_tsquery_content(self, query, config=None, invert=False):
         if isinstance(query, PlainText):
-            terms = re.split(r"[\s\-]+", query.query_string)
+            terms = [term for term in re.split(r"[\s\-]+", query.query_string) if term]
             if not terms:
                 return None
 

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -451,6 +451,24 @@ class BackendTests:
             ],
         )
 
+    def test_autocomplete_trailing_hyphen(self):
+        book = models.Book.objects.create(
+            title="Poseidon-1234ABC",
+            number_of_pages=350,
+            publication_date=date(1961, 11, 10),
+        )
+        self.backend.add(book)
+        self.backend.get_index_for_model(models.Book).refresh()
+
+        results = self.backend.autocomplete("poseidon-", models.Book)
+
+        self.assertCountEqual(
+            [r.title for r in results],
+            [
+                "Poseidon-1234ABC",
+            ],
+        )
+
     # FILTERING TESTS
 
     def test_filter_exact_value(self):


### PR DESCRIPTION
Fixes #89. After splitting plaintext terms on whitespace or hyphens, discard any empty sub-terms.

### AI usage

Used Github Copilot code completion.