### PR TITLE
Support django-tasks 0.12 on stable 1.2

### DIFF
--- a/modelsearch/__init__.py
+++ b/modelsearch/__init__.py
@@ -12,5 +12,5 @@ def format_version(version):
     return formatted
 
 
-VERSION = (1, 2, 1, "final", 0)
+VERSION = (1, 2, 2, "final", 0)
 __version__ = format_version(VERSION)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">= 3.10"
 dependencies = [
   "Django>=4.2",
-  "django-tasks>=0.7,<0.12",
+  "django-tasks>=0.7,<0.13",
 ]
 description = "A library for indexing Django models with Elasicsearch, OpenSearch or database and searching them with the Django ORM."
 readme = "README.md"


### PR DESCRIPTION
Updates the stable 1.2 branch metadata so modelsearch can be installed with django-tasks 0.12, where database and RQ backends are split into separate packages.

The code already uses the core django_tasks task API only. I verified the branch with Django 6.0.4, django-tasks 0.12.0, django-tasks-db 0.12.0, focused database-backend tests, and a django_tasks_db enqueue probe.\n\nThis also bumps the package version to 1.2.2 so Wagtail 7.3.x can consume a release inside its modelsearch>=1.1,<1.3 requirement range.