### PR TITLE
Resolve IndexEntry table dynamically in enable_trigram

### DIFF
--- a/modelsearch/management/commands/enable_trigram.py
+++ b/modelsearch/management/commands/enable_trigram.py
@@ -3,6 +3,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
+from modelsearch.conf import get_app_config
+
 
 class Command(BaseCommand):
     help = "Enable pg_trgm and unaccent extensions and create GIN trigram indexes for fuzzy search."
@@ -13,6 +15,9 @@ class Command(BaseCommand):
                 "This command only works with PostgreSQL databases. "
                 f"Current database vendor: {connection.vendor}"
             )
+
+        IndexEntry = get_app_config().get_model("IndexEntry", require_ready=False)
+        index_table = IndexEntry._meta.db_table
 
         # Enable pg_trgm extension
         with connection.cursor() as cursor:
@@ -39,16 +44,18 @@ class Command(BaseCommand):
                     "  CREATE EXTENSION IF NOT EXISTS pg_trgm;"
                 ) from e
 
+        quoted_table = connection.ops.quote_name(index_table)
+
         # Create accent-sensitive GIN indexes (for Fuzzy() without unaccent=True)
         try:
             with connection.cursor() as cursor:
                 cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS modelsearch_title_text_trgm "
-                    "ON modelsearch_indexentry USING gin (title_text gin_trgm_ops);"
+                    f"CREATE INDEX IF NOT EXISTS modelsearch_title_text_trgm "
+                    f"ON {quoted_table} USING gin (title_text gin_trgm_ops);"
                 )
                 cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS modelsearch_body_text_trgm "
-                    "ON modelsearch_indexentry USING gin (body_text gin_trgm_ops);"
+                    f"CREATE INDEX IF NOT EXISTS modelsearch_body_text_trgm "
+                    f"ON {quoted_table} USING gin (body_text gin_trgm_ops);"
                 )
             self.stdout.write(
                 self.style.SUCCESS("Created accent-sensitive GIN trigram indexes.")
@@ -60,12 +67,12 @@ class Command(BaseCommand):
         try:
             with connection.cursor() as cursor:
                 cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS modelsearch_title_text_unaccent_trgm "
-                    "ON modelsearch_indexentry USING gin (f_unaccent(title_text) gin_trgm_ops);"
+                    f"CREATE INDEX IF NOT EXISTS modelsearch_title_text_unaccent_trgm "
+                    f"ON {quoted_table} USING gin (f_unaccent(title_text) gin_trgm_ops);"
                 )
                 cursor.execute(
-                    "CREATE INDEX IF NOT EXISTS modelsearch_body_text_unaccent_trgm "
-                    "ON modelsearch_indexentry USING gin (f_unaccent(body_text) gin_trgm_ops);"
+                    f"CREATE INDEX IF NOT EXISTS modelsearch_body_text_unaccent_trgm "
+                    f"ON {quoted_table} USING gin (f_unaccent(body_text) gin_trgm_ops);"
                 )
             self.stdout.write(
                 self.style.SUCCESS("Created accent-insensitive GIN trigram indexes.")


### PR DESCRIPTION
Fixes #99.

The four `CREATE INDEX` statements in `enable_trigram` hardcoded the table name `modelsearch_indexentry`. That's correct when modelsearch is installed as its own app, but when used through Wagtail — where `WagtailSearchAppConfig` is registered with `label="wagtailsearch"` — the concrete `IndexEntry` table is `wagtailsearch_indexentry` and the command fails with:

```
CommandError: Failed to create trigram indexes: relation "modelsearch_indexentry" does not exist
```

`pg_trgm` ends up enabled but no usable indexes are created, so `Fuzzy()` queries silently degrade.

### Fix

Resolve the table via the same lookup the postgres backend already uses in `backends/database/postgres/postgres.py:60`:

```python
IndexEntry = get_app_config().get_model("IndexEntry", require_ready=False)
```

The resulting `IndexEntry._meta.db_table` is quoted with `connection.ops.quote_name()` and inlined into the four `CREATE INDEX` statements.

Index names are deliberately left at their historical `modelsearch_*` prefix so:
- existing standalone installs that already ran `enable_trigram` stay idempotent on rerun, and
- downstream reverse SQL (e.g. Wagtail's `wagtailsearch.0010_add_text_fields`, which drops `modelsearch_*` indexes on rollback) keeps working.

### Verification

- **Standalone modelsearch** (`runtests.py --backend db` against Postgres 18): all 1352 tests that were passing on `upstream/main` still pass; the 2 pre-existing `test_get_ancestors_filter` errors (django-treebeard MP_Node related, unchanged) are unaffected.
- **Wagtail-integrated** (Wagtail 7.4.1, `WAGTAILSEARCH_BACKENDS=wagtail.search.backends.database`): `enable_trigram` now creates all four GIN indexes on `wagtailsearch_indexentry`; rerun is a no-op; `Fuzzy()` and `Fuzzy(unaccent=True)` return matches as expected.

Happy to add a regression test if you'd like — would need to mock or swap the registered `ModelSearchAppConfig` since the existing test suite always runs under `label="modelsearch"`.