### PR TITLE
fix: handle single-join M2M path in _get_filter_field_path_for_column (Fixes #100)

### DIFF
--- a/modelsearch/backends/base.py
+++ b/modelsearch/backends/base.py
@@ -169,6 +169,14 @@ class BaseSearchQueryCompiler:
                                 search_fields = search_field.fields
                                 path.append(search_field)
                                 break
+                        else:
+                            # The M2M join was optimised into a single join step
+                            # (e.g. when filtering on the M2M through table's own columns).
+                            # Consume it and descend into the RelatedFields definition.
+                            model = field.related_model
+                            search_fields = search_field.fields
+                            path.append(search_field)
+                            break
 
                 else:
                     # no matching RelatedFields entry found


### PR DESCRIPTION
## Problem

When using `ParentalManyToManyField` with a `FilterField` on the related model's ID (e.g. `index.FilterField('researchservice_id')`), v1.3.1 raises a `FilterFieldError`:

> Cannot filter search results with field "researchservice_id". Please add a suitable index.RelatedFields definition.

Even wrapping in `index.RelatedFields` doesn't help, because the M2M join handling in `_get_filter_field_path_for_column` only works when there are remaining `table_aliases` to peek at.

## Root Cause

In `backends/base.py`, the M2M handling code at the join traversal loop checks:

```python
if table_aliases:
    table2 = self.queryset.query.alias_map[table_aliases[-1]]
    if table2.join_field == field.path_infos[1].join_field:
        ...
```

When the M2M join is optimised into a single join step (so `table_aliases` is empty at this point), the code falls through to the `for/else` branch and raises `FilterFieldError`.

## Fix

Added an `else` clause to handle the case where `table_aliases` is empty but the M2M field's first path_info matches the current join. This consumes the join and descends into the `RelatedFields` definition.

Fixes #100
