### PR TITLE
Upgrade Vagrant box to Ubuntu 26.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,8 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "bento/ubuntu-24.04"
-  config.vm.box_version = "202508.03.0"
+  config.vm.box = "bento/ubuntu-26.04"
+  config.vm.box_version = "202606.01.0"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
This upgrades MySQL to 8.4, which is the earliest version supported by Django >=6.1
