### PR TITLE
Disable indexing signals during fixture loading

### DIFF
--- a/modelsearch/signal_handlers.py
+++ b/modelsearch/signal_handlers.py
@@ -5,6 +5,9 @@ from .tasks import insert_or_update_object_task
 
 
 def post_save_signal_handler(instance, **kwargs):
+    if kwargs.get("raw", False):
+        return
+
     insert_or_update_object_task.enqueue(
         instance._meta.app_label, instance._meta.model_name, str(instance.pk)
     )

--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -35,12 +35,7 @@ from modelsearch.query import (
 from modelsearch.test.testapp import models
 
 
-class BackendTests:
-    # To test a specific backend, subclass BackendTests and define self.backend_path.
-    backend_path = None
-
-    fixtures = ["search"]
-
+class BackendTestSetupMixin:
     def setUp(self):
         # Search MODELSEARCH_BACKENDS for an entry that uses the given backend path
         for backend_name, backend_conf in settings.MODELSEARCH_BACKENDS.items():
@@ -55,7 +50,7 @@ class BackendTests:
             )
 
         # HACK: This is a hack to delete all the index entries that may be present in the test database before each test is run.
-        IndexEntry.objects.all().delete()
+        self.clear_index_entries()
 
         management.call_command(
             "rebuild_modelsearch_index",
@@ -63,6 +58,16 @@ class BackendTests:
             stdout=StringIO(),
             chunk_size=50,
         )
+
+    def clear_index_entries(self):
+        IndexEntry.objects.all().delete()
+
+
+class BackendTests(BackendTestSetupMixin):
+    # To test a specific backend, subclass BackendTests and define self.backend_path.
+    backend_path = None
+
+    fixtures = ["search"]
 
     # SEARCH TESTS
 
@@ -172,13 +177,22 @@ class BackendTests:
         results = list(
             self.backend.search("JavaScript Definitive", models.Book, operator="or")
         )
-        self.assertCountEqual(
+        # "JavaScript: The Definitive Guide" should be first
+        self.assertEqual(
+            [r.title for r in results],
+            ["JavaScript: The Definitive Guide", "JavaScript: The good parts"],
+        )
+
+        self.assertEqual(results[0].title, "JavaScript: The Definitive Guide")
+
+        results = list(
+            self.backend.search("JavaScript good", models.Book, operator="or")
+        )
+        # "JavaScript: The good parts" should be first
+        self.assertEqual(
             [r.title for r in results],
             ["JavaScript: The good parts", "JavaScript: The Definitive Guide"],
         )
-
-        # "JavaScript: The Definitive Guide" should be first
-        self.assertEqual(results[0].title, "JavaScript: The Definitive Guide")
 
     def test_annotate_score(self):
         results = self.backend.search("JavaScript", models.Book).annotate_score(

--- a/modelsearch/tests/test_mysql_backend.py
+++ b/modelsearch/tests/test_mysql_backend.py
@@ -24,6 +24,10 @@ from modelsearch.tests.test_backends import BackendTests
 class TestMySQLSearchBackend(BackendTests, TransactionTestCase):
     backend_path = "modelsearch.backends.database.mysql.mysql"
 
+    def clear_index_entries(self):
+        cursor = connection.cursor()
+        cursor.execute("TRUNCATE TABLE modelsearch_indexentry")
+
     # Overrides parent method, because there's a slight difference in what the MySQL backend supports/accepts as search queries.
     def test_not(self):
         all_other_titles = {

--- a/modelsearch/tests/test_postgres_backend.py
+++ b/modelsearch/tests/test_postgres_backend.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 from modelsearch.models import IndexEntry
 from modelsearch.query import Fuzzy, Phrase
 from modelsearch.test.testapp import models
-from modelsearch.tests.test_backends import BackendTests
+from modelsearch.tests.test_backends import BackendTests, BackendTestSetupMixin
 
 
 @unittest.skipUnless(
@@ -316,14 +316,11 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
         }
     }
 )
-class TestPostgresFuzzyThreshold(TestCase):
+class TestPostgresFuzzyThreshold(BackendTestSetupMixin, TestCase):
     """Test configurable fuzzy similarity threshold."""
 
     fixtures = ["search"]
     backend_path = "modelsearch.backends.database.postgres.postgres"
-
-    def setUp(self):
-        BackendTests.setUp(self)
 
     def test_fuzzy_threshold_from_settings(self):
         """
@@ -353,14 +350,11 @@ class TestPostgresFuzzyThreshold(TestCase):
         }
     }
 )
-class TestPostgresFuzzyPrefixBoost(TestCase):
+class TestPostgresFuzzyPrefixBoost(BackendTestSetupMixin, TestCase):
     """Test configurable fuzzy prefix boost."""
 
     fixtures = ["search"]
     backend_path = "modelsearch.backends.database.postgres.postgres"
-
-    def setUp(self):
-        BackendTests.setUp(self)
 
     def test_backend_has_prefix_boost_attribute(self):
         """Test that the backend has the fuzzy_prefix_boost attribute."""
@@ -412,14 +406,11 @@ class TestPostgresFuzzyPrefixBoost(TestCase):
         }
     }
 )
-class TestPostgresFuzzyLevenshtein(TestCase):
+class TestPostgresFuzzyLevenshtein(BackendTestSetupMixin, TestCase):
     """Test Levenshtein distance fuzzy search algorithm."""
 
     fixtures = ["search"]
     backend_path = "modelsearch.backends.database.postgres.postgres"
-
-    def setUp(self):
-        BackendTests.setUp(self)
 
     def test_backend_has_algorithm_attribute(self):
         """Test that the backend has the fuzzy_algorithm attribute."""
@@ -584,13 +575,13 @@ class TestPostgresFuzzyLevenshteinRanking(TestCase):
         }
     }
 )
-class TestPostgresFuzzyUnaccent(TestCase):
+class TestPostgresFuzzyUnaccent(BackendTestSetupMixin, TestCase):
     """Test accent-insensitive fuzzy search using Fuzzy(unaccent=True)."""
 
     backend_path = "modelsearch.backends.database.postgres.postgres"
 
     def setUp(self):
-        BackendTests.setUp(self)
+        super().setUp()
         models.Book.objects.all().delete()
 
     def _create_and_index(self, titles):
@@ -658,12 +649,12 @@ class TestPostgresFuzzyUnaccent(TestCase):
         }
     }
 )
-class TestPostgresLanguageTextSearch(TestCase):
+class TestPostgresLanguageTextSearch(BackendTestSetupMixin, TestCase):
     backend_path = "modelsearch.backends.database.postgres.postgres"
 
     def setUp(self):
         # get search backend by backend_path
-        BackendTests.setUp(self)
+        super().setUp()
 
         book = models.Book.objects.create(
             title="Nu is beter dan nooit",


### PR DESCRIPTION
### Description

Update the `post_save` signal to check if `raw=True` has been passed, and skip indexing if so. As per [the Django docs](https://docs.djangoproject.com/en/stable/ref/signals/#django.db.models.signals.post_save):

> One should not query/modify other records in the database as the database might not be in a consistent state yet.

Specifically, this arises when loading fixtures: Django disables referential integrity checks to allow for foreign keys that point to records later in the fixture file. If we attempted to index such a record (and the foreign key in question had a RelatedFields definition to cause the indexer to follow it), this would fail with a DoesNotExist exception. This started happening on our test fixtures following 06b331d0dbfdeb17fd4865c2186a4ac3255a839a.

Fixing this surfaces another issue on MySQL: `test_ranking` now fails when running the full test suite. It seems that the scores returned by `MatchExpression` steadily decline after repeated insertions and deletions - evidently it's holding on to some internal state from the deleted records that only gets reset when running `TRUNCATE TABLE` on `modelsearch_indexentry`. I suspect that this previously worked because there were _so many_ insertions and deletions that the rankings settled into a stable state that was consistent with the expected result. For this PR I've fixed this by running `TRUNCATE` between tests, but this ought to be investigated further to see if it leads to broken rankings in real-world use.

### AI usage

Github Copilot for code completion; ChatGPT for troubleshooting the MySQL ranking issue (which led to the suggestion of using TRUNCATE in place of DELETE).