### PR TITLE
Avoid unnecessary manual index insertions during tests

### DIFF
--- a/modelsearch/tests/test_backends.py
+++ b/modelsearch/tests/test_backends.py
@@ -458,12 +458,11 @@ class BackendTests(BackendTestSetupMixin):
         )
 
     def test_autocomplete_hyphenated_term(self):
-        book = models.Book.objects.create(
+        models.Book.objects.create(
             title="Poseidon-1234ABC",
             number_of_pages=350,
             publication_date=date(1961, 11, 10),
         )
-        self.backend.add(book)
         self.backend.get_index_for_model(models.Book).refresh()
 
         results = self.backend.autocomplete("poseidon-1234", models.Book)
@@ -476,12 +475,11 @@ class BackendTests(BackendTestSetupMixin):
         )
 
     def test_autocomplete_trailing_hyphen(self):
-        book = models.Book.objects.create(
+        models.Book.objects.create(
             title="Poseidon-1234ABC",
             number_of_pages=350,
             publication_date=date(1961, 11, 10),
         )
-        self.backend.add(book)
         self.backend.get_index_for_model(models.Book).refresh()
 
         results = self.backend.autocomplete("poseidon-", models.Book)
@@ -1339,6 +1337,8 @@ class BackendTests(BackendTestSetupMixin):
             if book.id in SCIFI_BOOKS:
                 book.tags.add("Science Fiction")
 
+            # adding a related object doesn't trigger the post_save signal to reindex the book,
+            # so we need to manually add it to the index
             self.backend.add(book)
 
         index = self.backend.get_index_for_model(models.Book)
@@ -1371,15 +1371,15 @@ class BackendTests(BackendTestSetupMixin):
         # across pages (see https://github.com/wagtail/wagtail/issues/3729).
         same_rank_objects = set()
 
-        index = self.backend.get_index_for_model(models.Book)
         for i in range(10):
             obj = models.Book.objects.create(
                 title=f"Rank {i}",
                 publication_date=date(2017, 10, 18),
                 number_of_pages=100,
             )
-            index.add_item(obj)
             same_rank_objects.add(obj)
+
+        index = self.backend.get_index_for_model(models.Book)
         index.refresh()
 
         results = self.backend.search("Rank", models.Book)
@@ -1391,13 +1391,12 @@ class BackendTests(BackendTestSetupMixin):
     def test_delete(self):
         foundation = models.Novel.objects.filter(title="Foundation").first()
 
-        # Delete from the search index
-        index = self.backend.get_index_for_model(models.Novel)
-        index.delete_item(foundation)
-        index.refresh()
-
         # Delete from the database
         foundation.delete()
+
+        # Refresh the search index
+        index = self.backend.get_index_for_model(models.Novel)
+        index.refresh()
 
         # To test that the book was deleted from the index as well, we will perform the slicing check from an earlier
         # test where "Foundation" was the first result. We need to test it this way so we can pick up the case where
@@ -1691,24 +1690,30 @@ class BackendTests(BackendTestSetupMixin):
         self.assertEqual(results.count(), 1)
 
     def test_add_bulk(self):
+        # Create book records using bulk_create, so that we don't trigger the post_save signal
+        # (which would index them immediately and negate the need to call add_bulk)
         books = [
-            models.Book.objects.create(
+            models.Book(
                 title="Fifty Shades of Grey",
                 publication_date=date(2020, 1, 1),
                 number_of_pages=100,
             ),
-            models.Book.objects.create(
+            models.Book(
                 title="Fifty Shades Darker",
                 publication_date=date(2020, 2, 1),
                 number_of_pages=200,
             ),
-            models.Book.objects.create(
+            models.Book(
                 title="Fifty Shades Freed",
                 publication_date=date(2020, 3, 1),
                 number_of_pages=300,
             ),
         ]
-        self.backend.add_bulk(models.Book, books)
+        models.Book.objects.bulk_create(books)
+
+        self.backend.add_bulk(
+            models.Book, models.Book.objects.filter(title__startswith="Fifty Shades")
+        )
         self.backend.get_index_for_model(models.Book).refresh()
 
         results = self.backend.search("Fifty Shades", models.Book)


### PR DESCRIPTION
Various tests were redundantly calling self.backend.add on model instances created during tests. This is unnecessary because the post_save signal handler is in force (AUTO_UPDATE is True on the backend), and the task runner is set to ImmediateBackend (and since django-tasks 0.10 this no longer waits until the end of the transaction). However, calling refresh() on the index is still necessary to flush all pending operations at the Elasticsearch/Opensearch end.

test_add_bulk has the opposite problem - we don't want the signal to be triggered, so that we can verify that add_bulk is doing its job. So, create the records with bulk_create to bypass the signal.

### AI usage

None